### PR TITLE
app env should be fetched in runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ by adding `notify` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:notify, "~> 0.1.9"}]
+  [{:notify, "~> 0.1.10"}]
 end
 ```
 

--- a/lib/notify_apn.ex
+++ b/lib/notify_apn.ex
@@ -1,218 +1,215 @@
 defmodule Notify.APN do
-	require Logger
-	import Joken
-	@moduledoc """
-	A module for generating push notifications on the Apple Push Notification service using HTTP2 requests and the new .p8 key standard. This module will generate JWT tokens from the .p8 key and use them to push notifications to device IDs.
-	"""
+  require Logger
+  import Joken
 
-	@config Application.get_env(:notify, Notify.APN)
-	@key_id Keyword.get(@config, :key_id)
-	@team_id Keyword.get(@config, :team_id)
-	@bundle_id Keyword.get(@config, :bundle_id)
-	@key Keyword.get(@config, :key_path) |> JOSE.JWK.from_pem_file()
+  @moduledoc """
+  A module for generating push notifications on the Apple Push Notification service using HTTP2 requests and the new .p8 key standard. This module will generate JWT tokens from the .p8 key and use them to push notifications to device IDs.
+  """
 
+  @type result :: {atom(), String.t()}
 
-	@type result :: {atom(), String.t()}
+  @doc """
+  Push a notification to device
+  """
+  @spec push(String.t(), Map.t()) :: result
+  def push(
+        device,
+        %Notification{
+          data: data,
+          sound: sound,
+          voip: true
+        }
+      ) do
+    [
+      {":authority", get_url() |> to_string()},
+      {":method", "POST"},
+      {":path", "/3/device/#{device}"},
+      {"authorization", "bearer " <> get_token()},
+      {"apns-topic", "#{config(:bundle_id)}.voip"},
+      {"apns-expiration", "0"},
+      {"apns-priority", "10"}
+    ]
+    |> dispatch(
+      %{
+        "data" => data,
+        "aps" => %{
+          "sound" => sound
+        }
+      },
+      device
+    )
+  end
 
-	unless Application.get_all_env(:notify) do
-		raise "Notify is not configured"
-	end
+  @spec push(String.t(), Map.t()) :: result
+  def push(
+        device,
+        %Notification{
+          title: title,
+          message: message,
+          expiration: expiration,
+          priority: priority,
+          data: data,
+          sound: _sound,
+          voip: false
+        } = notification
+      ) do
+    priority = if priority == "low", do: "5", else: "10"
 
-	if @config do
-		unless @key do
-			raise """
-			Could not read key file. Provide a path (full, with filename) to a valid .p8 file in config.
-			"""
-		end
+    aps_payload =
+      %{
+        "alert" => %{
+          "title" => title,
+          "body" => message
+        }
+      }
+      |> maybe_attach_content_available(notification)
+      |> maybe_attach_badge(notification)
 
-		unless @key_id do
-			raise """
-			:key_id is not configured. Add the Key ID of your APNsAuthKey_APPLE_KEY_ID.p8 file to config.
-			"""
-		end
+    [
+      {":authority", get_url() |> to_string()},
+      {":method", "POST"},
+      {":path", "/3/device/#{device}"},
+      {"authorization", "bearer " <> get_token()},
+      # TODO: remove .voip and find a way to mix regular and voip tokens
+      {"apns-topic", "#{config(:bundle_id)}.voip"},
+      {"apns-expiration", expiration |> to_string()},
+      {"apns-priority", priority}
+    ]
+    |> dispatch(
+      %{
+        "data" => data,
+        "aps" => aps_payload
+      },
+      device
+    )
+  end
 
-		unless String.length(@team_id) == 10 do
-			raise """
-			Invalid :team_id (must be 10 characters). Find :team_id in Xcode or in your Apple Developer account"
-			"""
-		end
+  @spec dispatch(List.t(), Map.t(), String.t()) :: result
+  defp dispatch(headers, body, device) do
+    with {:ok, pid} = Kadabra.open(get_url(), :https) do
+      Kadabra.request(pid, headers, Poison.encode!(body))
 
-		unless @bundle_id do
-			raise """
-			Missing :bundle_id from configuration. :bundle_id is Apples internal ID for your application.
-			"""
-		end
-	end
+      receive do
+        {:end_stream, %Kadabra.Stream{} = stream} -> reply(stream, device)
+      after
+        5_000 ->
+          reply(:timeout, device)
+      end
+    end
+  end
 
-	@doc """
-	Push a notification to device
-	"""
-	@spec push(String.t(), Map.t()) :: result
-	def push device,
-		%Notification{
-			data: data,
-			sound: sound,
-			voip: true
-		}
-	do
-		[
-			{":authority", get_url() |> to_string()},
-			{":method", "POST"},
-			{":path", "/3/device/#{device}"},
-			{"authorization", "bearer " <> get_token()},
-			{"apns-topic", "#{@bundle_id}.voip" },
-			{"apns-expiration", "0"},
-			{"apns-priority", "10"}
-		]
-		|> dispatch(%{
-			"data" => data,
-			"aps" => %{
-				"sound" => sound
-			}
-		}, device)
-	end
+  @doc """
+  Initiates a table to store APNs JWTs
+  """
+  @spec init_table() :: atom()
+  def init_table(), do: :ets.new(:apns_tokens, [:set, :public, :named_table])
 
-	@spec push(String.t(), Map.t()) :: result
-	def push device,
-		%Notification{
-			title: title,
-			message: message,
-			expiration: expiration,
-			priority: priority,
-			data: data,
-			sound: _sound,
-			voip: false
-		} = notification
-	do
-		priority = if priority == "low", do: "5", else: "10"
-		aps_payload =
-			%{
-				"alert" => %{
-					"title" => title,
-					"body" => message
-				}
-			}
-			|> maybe_attach_content_available(notification)
-			|> maybe_attach_badge(notification)
+  @doc """
+  Creates a JWT (valid for one hour after timestamp) and inserts it
+  in memory storage
+  """
+  @spec create_token() :: String.t()
+  def create_token() do
+    time = timestamp()
 
-		[
-			{":authority", get_url() |> to_string()},
-			{":method", "POST"},
-			{":path", "/3/device/#{device}"},
-			{"authorization", "bearer " <> get_token()},
-			{"apns-topic", "#{@bundle_id}.voip" }, # TODO: remove .voip and find a way to mix regular and voip tokens
-			{"apns-expiration", expiration |> to_string()},
-			{"apns-priority", priority}
-		]
-		|> dispatch(%{
-				"data" => data,
-				"aps" => aps_payload
-			}, device)
-	end
+    new_token =
+      %{"iss" => config(:team_id), "iat" => time}
+      |> token
+      |> with_header_arg("kid", config(:key_id))
+      |> sign(es256(key()))
+      |> get_compact()
 
-	@spec dispatch(List.t(), Map.t(), String.t()) :: result
-	defp dispatch(headers, body, device) do
-		with {:ok, pid} = Kadabra.open(get_url(), :https) do
-			Kadabra.request(pid, headers, Poison.encode!(body) )
-			receive do
-				{:end_stream, %Kadabra.Stream{} = stream} -> reply(stream, device)
-			after 5_000 ->
-				reply(:timeout, device)
-			end
-		end
-	end
+    :ets.insert(:apns_tokens, {"token", new_token, time + 3000})
 
-	@doc """
-	Initiates a table to store APNs JWTs
-	"""
-	@spec init_table() :: atom()
-	def init_table(), do: :ets.new(:apns_tokens, [:set, :public, :named_table])
+    to_string(new_token)
+  end
 
-	@doc """
-	Creates a JWT (valid for one hour after timestamp) and inserts it
-	in memory storage
-	"""
-	@spec create_token() :: String.t()
-	def create_token() do
-		time = timestamp()
+  @doc """
+  Gets JWT from memory
+  """
+  @spec get_token() :: String.t()
+  def get_token() do
+    case :ets.lookup(:apns_tokens, "token") do
+      [{_, stored_token, expires}] -> check_expiration({stored_token, expires})
+      _ -> create_token()
+    end
+  end
 
-		new_token = %{ "iss" => @team_id, "iat" => time }
-		|> token
-		|> with_header_arg("kid", @key_id)
-		|> sign(es256(@key))
-		|> get_compact()
+  @spec check_expiration({String.t(), Number.t()}) :: String.t()
+  defp check_expiration({stored_token, exp}) do
+    time = timestamp()
 
-		:ets.insert(:apns_tokens, {"token", new_token, time + 3000})
+    if exp >= time do
+      # Expiration is set to 60 seconds before actual expiration on APNs
+      Logger.debug("Stored token is valid for #{exp - time} more seconds")
+      stored_token
+    else
+      Logger.debug("Stored token has been expired for #{time - exp} seconds")
+      create_token()
+    end
+  end
 
-		to_string(new_token)
-	end
+  @spec reply(%Kadabra.Stream{}, String.t()) :: result
+  defp reply(%Kadabra.Stream{:status => 200, :headers => headers}, device_id) do
+    Logger.info("Notification to #{device_id} succeeded")
+    [_, {"apns-id", notification_id}] = headers
+    {:ok, notification_id}
+  end
 
-	@doc """
-	Gets JWT from memory
-	"""
-	@spec get_token() :: String.t()
-	def get_token() do
-		case :ets.lookup(:apns_tokens, "token") do
-			[{ _, stored_token, expires}] -> check_expiration({stored_token, expires})
-			_ -> create_token()
-		end
-	end
+  defp reply(%Kadabra.Stream{} = response, device_id) do
+    reason =
+      response
+      |> Map.get(:body, "")
+      |> Poison.decode!()
+      |> Map.get("reason", "Unexpected status")
 
-	@spec check_expiration({ String.t(), Number.t() }) :: String.t()
-	defp check_expiration({stored_token, exp}) do
-		time = timestamp()
-		if exp >= time do
-			# Expiration is set to 60 seconds before actual expiration on APNs
-			Logger.debug "Stored token is valid for #{exp - time} more seconds"
-			stored_token
-		else
-			Logger.debug "Stored token has been expired for #{time - exp} seconds"
-			create_token()
-		end
-	end
+    Logger.warn("Notification to #{device_id} failed: #{reason}")
+    {:error, reason}
+  end
 
-	@spec reply(%Kadabra.Stream{}, String.t()) :: result
-	defp reply(%Kadabra.Stream{:status => 200, :headers => headers}, device_id) do
-		Logger.info "Notification to #{device_id} succeeded"
-		[_, {"apns-id", notification_id}] = headers
-		{:ok, notification_id}
-	end
+  @spec reply(atom(), String.t()) :: result
+  defp reply(:timeout, device_id) do
+    Logger.warn("Notification to #{device_id} timed out.")
+    {:error, "Request timed out"}
+  end
 
-	defp reply(%Kadabra.Stream{} = response, device_id) do
-		reason = response
-		|> Map.get(:body, "")
-		|> Poison.decode!
-		|> Map.get("reason", "Unexpected status")
-		Logger.warn "Notification to #{device_id} failed: #{reason}"
-		{:error, reason}
-	end
+  @spec maybe_attach_content_available(map(), %Notification{}) :: map()
+  defp maybe_attach_content_available(payload, %Notification{
+         content_available: content_available,
+         priority: priority
+       })
+       when content_available != nil and priority != "low",
+       do: Map.put(payload, "content-available", content_available)
 
-	@spec reply(atom(), String.t()) :: result
-	defp reply(:timeout, device_id) do
-		Logger.warn "Notification to #{device_id} timed out."
-		{:error, "Request timed out"}
-	end
+  defp maybe_attach_content_available(payload, _), do: payload
 
-	@spec maybe_attach_content_available(map(), %Notification{}) :: map()
-	defp maybe_attach_content_available(payload, %Notification{content_available: content_available, priority: priority})
-	when content_available != nil and priority != "low", do: Map.put(payload, "content-available", content_available)
-	defp maybe_attach_content_available(payload, _), do: payload
+  @spec maybe_attach_badge(map(), %Notification{}) :: map()
+  defp maybe_attach_badge(payload, %Notification{badge: badge})
+       when badge != nil,
+       do: Map.put(payload, "badge", badge)
 
-	@spec maybe_attach_badge(map(), %Notification{}) :: map()
-	defp maybe_attach_badge(payload, %Notification{badge: badge})
-	when badge != nil, do: Map.put(payload, "badge", badge)
-	defp maybe_attach_badge(payload, _), do: payload
+  defp maybe_attach_badge(payload, _), do: payload
 
+  # Kadabra requires a charlist as address
+  @spec get_url() :: binary()
+  defp get_url() do
+    if Application.get_env(:notify, :production) do
+      'api.push.apple.com'
+    else
+      'api.development.push.apple.com'
+    end
+  end
 
-	@spec get_url() :: binary() # Kadabra requires a charlist as address
-	defp get_url() do
-		if Application.get_env(:notify, :production) do
-			'api.push.apple.com'
-		else
-			'api.development.push.apple.com'
-		end
-	end
+  @spec timestamp() :: number()
+  defp timestamp(), do: DateTime.utc_now() |> DateTime.to_unix()
 
-	@spec timestamp() :: number()
-	defp timestamp(), do: DateTime.utc_now() |> DateTime.to_unix()
+  @spec key() :: %JOSE.JWK{}
+  defp key(), do: JOSE.JWK.from_pem_file(config(:key_path))
+
+  @spec config(atom()) :: Keyword.t()
+  defp config(key) do
+    :notify
+    |> Application.fetch_env!(Notify.APN)
+    |> Keyword.fetch!(key)
+  end
 end

--- a/lib/notify_gcm.ex
+++ b/lib/notify_gcm.ex
@@ -1,68 +1,56 @@
 defmodule Notify.GCM do
-	@moduledoc """
-	A module for generating push notifications on the Firebase Cloud Messaging platform (from Google) using HTTP requests.
-	"""
+  @moduledoc """
+  A module for generating push notifications on the Firebase Cloud Messaging platform (from Google) using HTTP requests.
+  """
 
-	require Logger
+  require Logger
 
-	@config        Application.get_env(:notify, Notify.GCM) || []
-  @server_id     Keyword.get(@config, :server_id)
-  @server_key    Keyword.get(@config, :server_key)
-  @sender_id     Keyword.get(@config, :sender_id)
-	@url "https://gcm-http.googleapis.com/gcm/send"
-	@type result :: {atom(), String.t()}
+  @url "https://gcm-http.googleapis.com/gcm/send"
+  @type result :: {atom(), String.t()}
 
-	if @config != [] do
-		unless @server_key do
-			raise """
-			Missing API key for Google Cloud Messaging in configuration. Find it at:
-            https://console.developers.google.com/apis/credentials
-			"""
-		end
-	end
+  @doc """
+  Send a push notification through the Google Cloud Messaging service.
+  """
+  @spec push(Map.t()) :: result
+  def push(%{"to" => device_id} = notification) do
+    Logger.info("Pushing notification to #{device_id}")
 
-	@doc """
-	Send a push notification through the Google Cloud Messaging service.
-	"""
-	@spec push(Map.t()) :: result
-	def push(%{ "to" => device_id } = notification) do
-		Logger.info "Pushing notification to #{device_id}"
+    body = Poison.encode!(notification)
 
-		body = Poison.encode!(notification)
-		headers = [
-			"Content-Type": "application/json",
-			"Authorization": "key=#{@server_key}"
-		]
+    headers = [
+      "Content-Type": "application/json",
+      Authorization: "key=#{server_key()}"
+    ]
 
-		HTTPotion.post(@url, body: body, headers: headers)
-		|> parse_response()
-	end
+    HTTPotion.post(@url, body: body, headers: headers)
+    |> parse_response()
+  end
 
+  @spec parse_response(%HTTPotion.Response{}) :: result
+  defp parse_response(%HTTPotion.Response{status_code: status, body: body}) do
+    Poison.decode!(body)
+    |> reply(status)
+  end
 
-	@spec parse_response(%HTTPotion.Response{}) :: result
-	defp parse_response(%HTTPotion.Response{ status_code: status, body: body }) do
-		Poison.decode!(body)
-		|> reply(status)
-	end
+  @spec reply(Map.t(), integer()) :: result
+  defp reply(%{"results" => [%{"message_id" => id}]}, 200) do
+    Logger.info("Notification succeded")
+    {:ok, id}
+  end
 
-	@spec reply(Map.t(), integer()) :: result
-	defp reply(%{"results" => [%{ "message_id" => id}]}, 200) do
-		Logger.info "Notification succeded"
-		{:ok, id}
-	end
+  @spec reply(Map.t(), integer()) :: result
+  defp reply(%{"results" => [%{"error" => error}]}, _status) do
+    {:error, error}
+  end
 
-	@spec reply(Map.t(), integer()) :: result
-	defp reply(%{"results" => [%{"error" => error}]}, _status) do
-		{:error, error}
-	end
+  @spec reply(Map.t(), integer()) :: result
+  defp reply(_body, 200) do
+    {:error, "Invalid body format"}
+  end
 
-	@spec reply(Map.t(), integer()) :: result
-	defp reply(_body, 200) do
-		{:error, "Invalid body format"}
-	end
+  @spec reply(Map.t(), integer()) :: result
+  defp reply(_body, status), do: {:error, "Unexpected status #{status}"}
 
-	@spec reply(Map.t(), integer()) :: result
-	defp reply(_body, status), do: {:error, "Unexpected status #{status}"}
-
-
+  @spec server_key() :: String.t()
+  defp server_key(), do: Application.get_env(:notify, Notify.GCM)[:server_key]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Notify.Mixfile do
 
   def project do
     [app: :notify,
-     version: "0.1.9",
+     version: "0.1.10",
      elixir: "~> 1.4",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Any application that uses this library as a dependency needs to recompile it every time when app/system env changes. Especially it is not suitable for the server-dependent environment.
To avoid this we should take app env in runtime, not in compile time.